### PR TITLE
Fix expect vs actual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 humanparser JavaScript Bug Squash
 =========
 
-`humanparser` is a third-party library we use at Remind to parse a human name string into salutation, first name, middle name, last name, and suffix.
+`humanparser` is a third-party library we previously used at ParentSquare to parse a human name string into salutation, first name, middle name, last name, and suffix.
 
 ## Requirements
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ parser.parseName = function (name) {
     var compound = ['vere', 'von', 'van', 'de', 'del', 'della', 'der', 'di', 'da', 'pietro', 'vanden', 'du', 'st.', 'st', 'la', 'lo', 'ter', 'bin', 'ibn', 'te', 'ten', 'op', 'ben'];
 
     var parts = name.trim().split(/\s+/);
-		var attrs = {};
+	var attrs = {};
 
     if (!parts.length) {
         return attrs;

--- a/test/index.js
+++ b/test/index.js
@@ -211,7 +211,7 @@ describe('Parsing names', function() {
         names.forEach(function(name, i, list){
             var parsed = human.parseName(name.name);
 
-            expect(name.result).to.eql(parsed);
+            expect(parsed).to.eql(name.result);
         });
     });
 
@@ -219,7 +219,7 @@ describe('Parsing names', function() {
         fullest.forEach(function(name, i, list){
             var fullName = human.getFullestName(name.name);
 
-            expect(name.result.fullName).to.eql(fullName);
+            expect(fullName).to.eql(name.result.fullName);
         });
     });
 
@@ -227,7 +227,7 @@ describe('Parsing names', function() {
         addresses.forEach(function(address, i, list){
             var parsed = human.parseAddress(address.address);
 
-            expect(address.result).to.eql(parsed);
+            expect(parsed).to.eql(address.result);
         });
     });
 });


### PR DESCRIPTION
When a test is failing, the output displays "actual" and "expected", but the values are reversed, which breaks the transparency around understanding the failure.

This PR just fixes the values so that the test failures report accurately.